### PR TITLE
disable compiler cache for cross-volume builds

### DIFF
--- a/compile.lisp
+++ b/compile.lisp
@@ -5,6 +5,7 @@
 
 
 (require :asdf)
+(asdf:disable-output-translations)
 (push #P"./" asdf:*central-registry*)
 (require :kenzo)
 (asdf:make-build :kenzo :type :fasl :monolithic t :move-here #P".")


### PR DESCRIPTION
This is needed to prevent an error arising from the cache and the build to be on different volumes, see https://trac.sagemath.org/ticket/27554